### PR TITLE
feat: integrate text analysis sentiment data into dashboards

### DIFF
--- a/apps/draft-api/src/commands/seed-all.ts
+++ b/apps/draft-api/src/commands/seed-all.ts
@@ -6,6 +6,7 @@ import { seedPlayers } from './seed-steps/seed-players';
 import { seedDraftClasses } from './seed-steps/seed-draft-classes';
 import { seedDraftClassGrades } from './seed-steps/seed-draft-class-grades';
 import { seedPlayerGrades } from './seed-steps/seed-player-grades';
+import { seedTextAnalysis } from './seed-steps/seed-text-analysis';
 import { SeedResult } from './seed';
 
 const YEARS = [2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025];
@@ -47,6 +48,11 @@ async function main() {
     const playerGradesResult = await seedPlayerGrades(year);
     results.push(playerGradesResult);
     console.log(`  Done: ${playerGradesResult.success} created, ${playerGradesResult.skipped} skipped`);
+
+    console.log(`--- Seeding text analysis (${year}) ---`);
+    const textAnalysisResult = await seedTextAnalysis(year);
+    results.push(textAnalysisResult);
+    console.log(`  Done: ${textAnalysisResult.success} analyzed, ${textAnalysisResult.skipped} skipped`);
   }
 
   // Summary

--- a/apps/draft-api/src/commands/seed-steps/seed-text-analysis.ts
+++ b/apps/draft-api/src/commands/seed-steps/seed-text-analysis.ts
@@ -1,0 +1,87 @@
+import { IsNull, Not } from 'typeorm';
+import { AppDataSource } from '../../database';
+import { DraftClassGrade } from '../../database/models/draft-class-grade';
+import { SeedResult } from '../seed';
+
+const TEXT_ANALYSIS_BASE_URL = process.env.TEXT_ANALYSIS_URL || 'http://localhost:3000';
+
+export async function seedTextAnalysis(year: number): Promise<SeedResult> {
+  const gradeRepository = AppDataSource.getRepository(DraftClassGrade);
+
+  // Find grades with text but no sentiment analysis yet
+  const grades = await gradeRepository.find({
+    where: {
+      year,
+      text: Not(IsNull()),
+      sentimentCompound: IsNull(),
+    },
+  });
+
+  if (grades.length === 0) {
+    console.log(`  No grades needing text analysis for ${year}.`);
+    return { step: 'text-analysis', success: 0, failed: 0, skipped: 0 };
+  }
+
+  console.log(`  Found ${grades.length} grades to analyze for ${year}.`);
+
+  let success = 0;
+  let failed = 0;
+
+  for (const grade of grades) {
+    try {
+      // Call sentiment analysis
+      const sentimentResponse = await fetch(`${TEXT_ANALYSIS_BASE_URL}/analyze/sentiment`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text: grade.text }),
+      });
+
+      if (!sentimentResponse.ok) {
+        throw new Error(`Sentiment API returned ${sentimentResponse.status}`);
+      }
+
+      const sentimentData = await sentimentResponse.json();
+
+      // Call word count
+      const wordCountResponse = await fetch(`${TEXT_ANALYSIS_BASE_URL}/wordcount`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text: grade.text }),
+      });
+
+      if (!wordCountResponse.ok) {
+        throw new Error(`Word count API returned ${wordCountResponse.status}`);
+      }
+
+      const wordCountData = await wordCountResponse.json();
+
+      // Sort keywords by count descending, take top 20
+      const keywords = Object.entries(wordCountData.word_count as Record<string, number>)
+        .map(([word, count]) => ({ word, count }))
+        .sort((a, b) => b.count - a.count)
+        .slice(0, 20);
+
+      // Update grade
+      grade.sentimentCompound = sentimentData.sentiment.compound;
+      grade.sentimentPositive = sentimentData.sentiment.pos;
+      grade.sentimentNegative = sentimentData.sentiment.neg;
+      grade.sentimentNeutral = sentimentData.sentiment.neu;
+      grade.keywords = keywords;
+
+      await gradeRepository.save(grade);
+      success++;
+
+      if (success % 10 === 0) {
+        console.log(`  Analyzed ${success}/${grades.length} grades...`);
+      }
+    } catch (error) {
+      console.error(
+        `  Failed to analyze grade ${grade.id}:`,
+        error instanceof Error ? error.message : String(error),
+      );
+      failed++;
+    }
+  }
+
+  return { step: 'text-analysis', success, failed, skipped: 0 };
+}

--- a/apps/draft-api/src/commands/seed.ts
+++ b/apps/draft-api/src/commands/seed.ts
@@ -6,8 +6,9 @@ import { seedDraftClassGrades } from './seed-steps/seed-draft-class-grades';
 import { seedPlayerGrades } from './seed-steps/seed-player-grades';
 import { seedPlayers } from './seed-steps/seed-players';
 import { seedTeams } from './seed-steps/seed-teams';
+import { seedTextAnalysis } from './seed-steps/seed-text-analysis';
 
-type StepName = 'teams' | 'players' | 'draft-classes' | 'grades' | 'player-grades';
+type StepName = 'teams' | 'players' | 'draft-classes' | 'grades' | 'player-grades' | 'text-analysis';
 
 export type SeedResult = {
   step: string;
@@ -16,7 +17,7 @@ export type SeedResult = {
   skipped: number;
 };
 
-const VALID_STEPS: StepName[] = ['teams', 'players', 'draft-classes', 'grades', 'player-grades'];
+const VALID_STEPS: StepName[] = ['teams', 'players', 'draft-classes', 'grades', 'player-grades', 'text-analysis'];
 
 function parseArgs(): { steps: StepName[] | null; year: number } {
   const args = process.argv.slice(2);
@@ -56,7 +57,7 @@ async function main() {
   console.log('Database connected.\n');
 
   const results: SeedResult[] = [];
-  const allSteps: StepName[] = ['teams', 'players', 'draft-classes', 'grades', 'player-grades'];
+  const allSteps: StepName[] = ['teams', 'players', 'draft-classes', 'grades', 'player-grades', 'text-analysis'];
   const stepsToRun = steps ?? allSteps;
 
   for (const step of stepsToRun) {
@@ -78,6 +79,9 @@ async function main() {
         break;
       case 'player-grades':
         result = await seedPlayerGrades(year);
+        break;
+      case 'text-analysis':
+        result = await seedTextAnalysis(year);
         break;
       default:
         console.log(`  Step "${step}" not yet implemented.\n`);

--- a/apps/draft-api/src/database/models/draft-class-grade.ts
+++ b/apps/draft-api/src/database/models/draft-class-grade.ts
@@ -39,6 +39,21 @@ export class DraftClassGrade {
   @Column({ nullable: true })
   text?: string;
 
+  @Column({ type: 'float', nullable: true })
+  sentimentCompound?: number;
+
+  @Column({ type: 'float', nullable: true })
+  sentimentPositive?: number;
+
+  @Column({ type: 'float', nullable: true })
+  sentimentNegative?: number;
+
+  @Column({ type: 'float', nullable: true })
+  sentimentNeutral?: number;
+
+  @Column({ type: 'jsonb', nullable: true })
+  keywords?: Array<{ word: string; count: number }>;
+
   @CreateDateColumn()
   createdAt: Date;
 

--- a/apps/draft-api/src/dtos/draft-summary.dto.ts
+++ b/apps/draft-api/src/dtos/draft-summary.dto.ts
@@ -14,6 +14,11 @@ export class TeamDraftSummaryDto {
     readonly gradeNumeric: number;
     readonly year: number;
     readonly text: string;
+    readonly sentimentCompound?: number | null;
+    readonly sentimentPositive?: number | null;
+    readonly sentimentNegative?: number | null;
+    readonly sentimentNeutral?: number | null;
+    readonly keywords?: Array<{ word: string; count: number }> | null;
     readonly sourceArticle: {
       readonly id: string;
       readonly title: string;

--- a/apps/draft-api/src/mappers/draft-summary.mapper.ts
+++ b/apps/draft-api/src/mappers/draft-summary.mapper.ts
@@ -10,6 +10,11 @@ export class DraftSummaryMapper {
         id: grade.id,
         year: grade.year,
         text: grade.text,
+        sentimentCompound: grade.sentimentCompound ?? null,
+        sentimentPositive: grade.sentimentPositive ?? null,
+        sentimentNegative: grade.sentimentNegative ?? null,
+        sentimentNeutral: grade.sentimentNeutral ?? null,
+        keywords: grade.keywords ?? null,
         sourceArticle: {
           id: grade.sourceArticle.id,
           title: grade.sourceArticle.title,

--- a/apps/draft-api/test/unit/commands/seed-text-analysis.test.ts
+++ b/apps/draft-api/test/unit/commands/seed-text-analysis.test.ts
@@ -1,0 +1,88 @@
+import { seedTextAnalysis } from '../../../src/commands/seed-steps/seed-text-analysis';
+
+// Mock AppDataSource
+jest.mock('../../../src/database', () => ({
+  AppDataSource: {
+    getRepository: jest.fn(),
+  },
+}));
+
+// Mock global fetch
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+import { AppDataSource } from '../../../src/database';
+
+describe('seedTextAnalysis', () => {
+  const mockGradeRepository = {
+    find: jest.fn(),
+    save: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (AppDataSource.getRepository as jest.Mock).mockReturnValue(mockGradeRepository);
+  });
+
+  it('should return zeros when no grades need analysis', async () => {
+    mockGradeRepository.find.mockResolvedValue([]);
+
+    const result = await seedTextAnalysis(2024);
+    expect(result).toEqual({ step: 'text-analysis', success: 0, failed: 0, skipped: 0 });
+  });
+
+  it('should call text-analysis-service and update grade', async () => {
+    const mockGrade = {
+      id: 'grade-1',
+      text: 'Great draft class with solid picks.',
+      sentimentCompound: null,
+    };
+    mockGradeRepository.find.mockResolvedValue([mockGrade]);
+
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          sentiment: { compound: 0.75, pos: 0.6, neg: 0.0, neu: 0.4 },
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          word_count: { draft: 5, class: 3, solid: 2, picks: 2, great: 1 },
+        }),
+      });
+
+    const result = await seedTextAnalysis(2024);
+
+    expect(result.success).toBe(1);
+    expect(mockGradeRepository.save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sentimentCompound: 0.75,
+        sentimentPositive: 0.6,
+        sentimentNegative: 0.0,
+        sentimentNeutral: 0.4,
+        keywords: [
+          { word: 'draft', count: 5 },
+          { word: 'class', count: 3 },
+          { word: 'solid', count: 2 },
+          { word: 'picks', count: 2 },
+          { word: 'great', count: 1 },
+        ],
+      }),
+    );
+  });
+
+  it('should handle text-analysis-service being unreachable', async () => {
+    const mockGrade = {
+      id: 'grade-1',
+      text: 'Some text',
+      sentimentCompound: null,
+    };
+    mockGradeRepository.find.mockResolvedValue([mockGrade]);
+    mockFetch.mockRejectedValue(new Error('ECONNREFUSED'));
+
+    const result = await seedTextAnalysis(2024);
+    expect(result.failed).toBe(1);
+  });
+});

--- a/apps/mmd-public/src/components/hero-stats.tsx
+++ b/apps/mmd-public/src/components/hero-stats.tsx
@@ -1,4 +1,4 @@
-import { SimpleGrid, Stat, StatLabel, StatNumber, StatHelpText, StatArrow, Text } from '@chakra-ui/react';
+import { SimpleGrid, Stat, StatLabel, StatNumber, StatHelpText, StatArrow } from '@chakra-ui/react';
 import Card from './card';
 import { GradeBadge } from './grade-badge';
 import { SentimentBadge } from './sentiment-badge';

--- a/apps/mmd-public/src/components/hero-stats.tsx
+++ b/apps/mmd-public/src/components/hero-stats.tsx
@@ -1,6 +1,12 @@
-import { SimpleGrid, Stat, StatLabel, StatNumber, StatHelpText, StatArrow } from '@chakra-ui/react';
+import { SimpleGrid, Stat, StatLabel, StatNumber, StatHelpText, StatArrow, Text } from '@chakra-ui/react';
 import Card from './card';
 import { GradeBadge } from './grade-badge';
+import { SentimentBadge } from './sentiment-badge';
+
+interface SentimentLeader {
+  team: { id: string; name: string };
+  sentiment: number;
+}
 
 interface HeroStatsProps {
   currentYear: number;
@@ -15,11 +21,16 @@ interface HeroStatsProps {
     leagueAverage: number;
     sourceAgreement: number;
   };
+  sentimentLeaders?: {
+    mostPositive: SentimentLeader | null;
+    mostCriticized: SentimentLeader | null;
+  };
 }
 
-export const HeroStats: React.FC<HeroStatsProps> = ({ stats, deltas }) => {
+export const HeroStats: React.FC<HeroStatsProps> = ({ stats, deltas, sentimentLeaders }) => {
+  const hasSentiment = sentimentLeaders?.mostPositive || sentimentLeaders?.mostCriticized;
   return (
-    <SimpleGrid columns={{ base: 1, md: 2, lg: 4 }} spacing={6} mb={12}>
+    <SimpleGrid columns={{ base: 1, md: 2, lg: hasSentiment ? 6 : 4 }} spacing={6} mb={12}>
       <Card variant="hero">
         <Stat>
           <StatLabel>League Average</StatLabel>
@@ -59,6 +70,34 @@ export const HeroStats: React.FC<HeroStatsProps> = ({ stats, deltas }) => {
           <StatHelpText>Across all sources</StatHelpText>
         </Stat>
       </Card>
+
+      {sentimentLeaders?.mostPositive && (
+        <Card variant="hero">
+          <Stat>
+            <StatLabel>Most Positive Buzz</StatLabel>
+            <StatNumber fontSize="lg">
+              {sentimentLeaders.mostPositive.team.name}
+            </StatNumber>
+            <StatHelpText>
+              <SentimentBadge sentiment={sentimentLeaders.mostPositive.sentiment} />
+            </StatHelpText>
+          </Stat>
+        </Card>
+      )}
+
+      {sentimentLeaders?.mostCriticized && (
+        <Card variant="hero">
+          <Stat>
+            <StatLabel>Most Criticized</StatLabel>
+            <StatNumber fontSize="lg">
+              {sentimentLeaders.mostCriticized.team.name}
+            </StatNumber>
+            <StatHelpText>
+              <SentimentBadge sentiment={sentimentLeaders.mostCriticized.sentiment} />
+            </StatHelpText>
+          </Stat>
+        </Card>
+      )}
     </SimpleGrid>
   );
 };

--- a/apps/mmd-public/src/components/sentiment-badge.tsx
+++ b/apps/mmd-public/src/components/sentiment-badge.tsx
@@ -1,0 +1,32 @@
+import { Badge, Tooltip } from '@chakra-ui/react';
+
+interface SentimentBadgeProps {
+  sentiment: number | null | undefined;
+}
+
+function getSentimentLabel(compound: number): string {
+  if (compound > 0.2) return 'Positive';
+  if (compound < -0.2) return 'Negative';
+  return 'Neutral';
+}
+
+function getSentimentColor(compound: number): string {
+  if (compound > 0.2) return 'green';
+  if (compound < -0.2) return 'red';
+  return 'gray';
+}
+
+export const SentimentBadge: React.FC<SentimentBadgeProps> = ({ sentiment }) => {
+  if (sentiment == null) return null;
+
+  const label = getSentimentLabel(sentiment);
+  const colorScheme = getSentimentColor(sentiment);
+
+  return (
+    <Tooltip label={`Sentiment: ${sentiment.toFixed(2)}`} placement="top">
+      <Badge colorScheme={colorScheme} variant="subtle" fontSize="xs" ml={2}>
+        {label}
+      </Badge>
+    </Tooltip>
+  );
+};

--- a/apps/mmd-public/src/components/sentiment-grade-scatter.tsx
+++ b/apps/mmd-public/src/components/sentiment-grade-scatter.tsx
@@ -1,0 +1,91 @@
+import { Box, Heading, Text } from '@chakra-ui/react';
+import {
+  ScatterChart,
+  Scatter,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  ReferenceLine,
+} from 'recharts';
+
+interface DataPoint {
+  source: string;
+  grade: number;
+  sentiment: number;
+}
+
+interface SentimentGradeScatterProps {
+  data: DataPoint[];
+}
+
+const SOURCE_COLORS = ['#4a90e2', '#e2844a', '#50c878', '#e24a6e', '#9b59b6', '#f1c40f', '#1abc9c'];
+
+export const SentimentGradeScatter: React.FC<SentimentGradeScatterProps> = ({ data }) => {
+  if (!data || data.length === 0) {
+    return (
+      <Box>
+        <Heading size="md" mb={4}>Sentiment vs Grade</Heading>
+        <Text color="gray.500">No sentiment data available</Text>
+      </Box>
+    );
+  }
+
+  const sourceGroups = new Map<string, DataPoint[]>();
+  for (const point of data) {
+    if (!sourceGroups.has(point.source)) {
+      sourceGroups.set(point.source, []);
+    }
+    sourceGroups.get(point.source)!.push(point);
+  }
+
+  const sources = Array.from(sourceGroups.keys());
+
+  return (
+    <Box>
+      <Heading size="md" mb={4}>Sentiment vs Grade</Heading>
+      <ResponsiveContainer width="100%" height={300}>
+        <ScatterChart margin={{ top: 10, right: 20, bottom: 10, left: 10 }}>
+          <XAxis
+            type="number"
+            dataKey="grade"
+            name="Grade"
+            domain={[0, 4.3]}
+            tick={{ fill: '#A0AEC0', fontSize: 12 }}
+            label={{ value: 'Grade', position: 'bottom', fill: '#A0AEC0' }}
+          />
+          <YAxis
+            type="number"
+            dataKey="sentiment"
+            name="Sentiment"
+            domain={[-1, 1]}
+            tick={{ fill: '#A0AEC0', fontSize: 12 }}
+            label={{ value: 'Sentiment', angle: -90, position: 'insideLeft', fill: '#A0AEC0' }}
+          />
+          <Tooltip
+            content={({ active, payload }) => {
+              if (!active || !payload?.length) return null;
+              const point = payload[0].payload as DataPoint;
+              return (
+                <Box bg="elevations.dark.dp08" p={3} rounded="lg">
+                  <Text fontWeight="bold">{point.source}</Text>
+                  <Text>Grade: {point.grade.toFixed(1)}</Text>
+                  <Text>Sentiment: {point.sentiment.toFixed(2)}</Text>
+                </Box>
+              );
+            }}
+          />
+          <ReferenceLine y={0} stroke="#718096" strokeDasharray="3 3" />
+          {sources.map((source, i) => (
+            <Scatter
+              key={source}
+              name={source}
+              data={sourceGroups.get(source)}
+              fill={SOURCE_COLORS[i % SOURCE_COLORS.length]}
+            />
+          ))}
+        </ScatterChart>
+      </ResponsiveContainer>
+    </Box>
+  );
+};

--- a/apps/mmd-public/src/components/source-tone-chart.tsx
+++ b/apps/mmd-public/src/components/source-tone-chart.tsx
@@ -1,0 +1,76 @@
+import { Box, Heading, Text } from '@chakra-ui/react';
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  Cell,
+  ReferenceLine,
+} from 'recharts';
+
+interface SourceToneChartProps {
+  data: Array<{ source: string; sentiment: number }>;
+  title?: string;
+}
+
+function getSentimentBarColor(sentiment: number): string {
+  if (sentiment > 0.2) return '#38A169';
+  if (sentiment < -0.2) return '#E53E3E';
+  return '#A0AEC0';
+}
+
+export const SourceToneChart: React.FC<SourceToneChartProps> = ({
+  data,
+  title = 'Source Tone Comparison',
+}) => {
+  if (!data || data.length === 0) {
+    return (
+      <Box>
+        <Heading size="md" mb={4}>{title}</Heading>
+        <Text color="gray.500">No sentiment data available</Text>
+      </Box>
+    );
+  }
+
+  return (
+    <Box>
+      <Heading size="md" mb={4}>{title}</Heading>
+      <ResponsiveContainer width="100%" height={Math.max(200, data.length * 50)}>
+        <BarChart data={data} layout="vertical" margin={{ left: 20, right: 20 }}>
+          <XAxis
+            type="number"
+            domain={[-1, 1]}
+            tickCount={5}
+            tick={{ fill: '#A0AEC0', fontSize: 12 }}
+          />
+          <YAxis
+            type="category"
+            dataKey="source"
+            width={120}
+            tick={{ fill: '#A0AEC0', fontSize: 12 }}
+          />
+          <Tooltip
+            content={({ active, payload }) => {
+              if (!active || !payload?.length) return null;
+              const item = payload[0].payload as { source: string; sentiment: number };
+              return (
+                <Box bg="elevations.dark.dp08" p={3} rounded="lg">
+                  <Text fontWeight="bold">{item.source}</Text>
+                  <Text>Sentiment: {item.sentiment.toFixed(2)}</Text>
+                </Box>
+              );
+            }}
+          />
+          <ReferenceLine x={0} stroke="#718096" strokeDasharray="3 3" />
+          <Bar dataKey="sentiment" maxBarSize={30}>
+            {data.map((entry, index) => (
+              <Cell key={index} fill={getSentimentBarColor(entry.sentiment)} />
+            ))}
+          </Bar>
+        </BarChart>
+      </ResponsiveContainer>
+    </Box>
+  );
+};

--- a/apps/mmd-public/src/components/sparkline.tsx
+++ b/apps/mmd-public/src/components/sparkline.tsx
@@ -5,19 +5,49 @@ import { Box } from '@chakra-ui/react';
 interface SparklineProps {
   data: Array<{ year: number; grade: number }>;
   color?: string;
+  sentimentData?: Array<{ year: number; sentiment: number }>;
 }
 
-export const Sparkline = React.memo<SparklineProps>(({ data, color = '#4a90e2' }) => {
+function getSentimentDotColor(sentiment: number): string {
+  if (sentiment > 0.2) return '#38A169';
+  if (sentiment < -0.2) return '#E53E3E';
+  return '#A0AEC0';
+}
+
+export const Sparkline = React.memo<SparklineProps>(({ data, color = '#4a90e2', sentimentData }) => {
+  const mergedData = sentimentData
+    ? data.map((d) => {
+        const match = sentimentData.find((s) => s.year === d.year);
+        return { ...d, sentiment: match?.sentiment ?? null };
+      })
+    : data;
+
+  const renderDot = sentimentData
+    ? (props: { cx?: number; cy?: number; payload?: { sentiment?: number | null } }) => {
+        const { cx, cy, payload } = props;
+        if (cx == null || cy == null || payload?.sentiment == null) return <></>;
+        return (
+          <circle
+            cx={cx}
+            cy={cy}
+            r={3}
+            fill={getSentimentDotColor(payload.sentiment)}
+            stroke="none"
+          />
+        );
+      }
+    : false;
+
   return (
     <Box display="inline-block" width="60px" height="24px" verticalAlign="middle">
       <ResponsiveContainer width="100%" height="100%">
-        <LineChart data={data}>
+        <LineChart data={mergedData}>
           <Line
             type="monotone"
             dataKey="grade"
             stroke={color}
             strokeWidth={2}
-            dot={false}
+            dot={renderDot}
             isAnimationActive={false}
           />
         </LineChart>

--- a/apps/mmd-public/src/components/word-cloud.tsx
+++ b/apps/mmd-public/src/components/word-cloud.tsx
@@ -1,0 +1,47 @@
+import { Box, Flex, Text, Heading } from '@chakra-ui/react';
+
+interface WordCloudProps {
+  keywords: Array<{ word: string; count: number }>;
+  color?: string;
+}
+
+export const WordCloud: React.FC<WordCloudProps> = ({ keywords, color = '#4a90e2' }) => {
+  if (!keywords || keywords.length === 0) {
+    return (
+      <Box>
+        <Heading size="md" mb={4}>Key Terms</Heading>
+        <Text color="gray.500">No text analysis data available</Text>
+      </Box>
+    );
+  }
+
+  const maxCount = Math.max(...keywords.map((k) => k.count));
+  const minSize = 0.75;
+  const maxSize = 2.0;
+
+  return (
+    <Box>
+      <Heading size="md" mb={4}>Key Terms</Heading>
+      <Flex flexWrap="wrap" gap={2} justifyContent="center" p={4}>
+        {keywords.map((kw) => {
+          const scale = maxCount > 0 ? kw.count / maxCount : 0;
+          const fontSize = minSize + scale * (maxSize - minSize);
+
+          return (
+            <Text
+              key={kw.word}
+              fontSize={`${fontSize}rem`}
+              fontWeight={scale > 0.5 ? 'bold' : 'normal'}
+              color={color}
+              opacity={0.5 + scale * 0.5}
+              px={1}
+              title={`${kw.word}: ${kw.count}`}
+            >
+              {kw.word}
+            </Text>
+          );
+        })}
+      </Flex>
+    </Box>
+  );
+};

--- a/apps/mmd-public/src/types/index.ts
+++ b/apps/mmd-public/src/types/index.ts
@@ -41,6 +41,11 @@ export interface DraftGrade {
   gradeNumeric: number;
   year: number;
   text: string;
+  sentimentCompound?: number | null;
+  sentimentPositive?: number | null;
+  sentimentNegative?: number | null;
+  sentimentNeutral?: number | null;
+  keywords?: Array<{ word: string; count: number }> | null;
   sourceArticle: {
     id: string;
     title: string;

--- a/apps/mmd-public/test/unit/components/sentiment-badge.test.tsx
+++ b/apps/mmd-public/test/unit/components/sentiment-badge.test.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { ChakraProvider } from '@chakra-ui/react';
+import { theme } from '../../../src/config/theme';
+import { SentimentBadge } from '../../../src/components/sentiment-badge';
+
+const renderWithTheme = (ui: React.ReactElement) =>
+  render(<ChakraProvider theme={theme}>{ui}</ChakraProvider>);
+
+describe('SentimentBadge', () => {
+  it('renders nothing when sentiment is null', () => {
+    renderWithTheme(<SentimentBadge sentiment={null} />);
+    expect(screen.queryByText('Positive')).not.toBeInTheDocument();
+    expect(screen.queryByText('Neutral')).not.toBeInTheDocument();
+    expect(screen.queryByText('Negative')).not.toBeInTheDocument();
+  });
+
+  it('shows positive badge for compound > 0.2', () => {
+    renderWithTheme(<SentimentBadge sentiment={0.75} />);
+    expect(screen.getByText('Positive')).toBeInTheDocument();
+  });
+
+  it('shows neutral badge for compound between -0.2 and 0.2', () => {
+    renderWithTheme(<SentimentBadge sentiment={0.1} />);
+    expect(screen.getByText('Neutral')).toBeInTheDocument();
+  });
+
+  it('shows negative badge for compound < -0.2', () => {
+    renderWithTheme(<SentimentBadge sentiment={-0.5} />);
+    expect(screen.getByText('Negative')).toBeInTheDocument();
+  });
+});

--- a/apps/mmd-public/test/unit/components/sentiment-grade-scatter.test.tsx
+++ b/apps/mmd-public/test/unit/components/sentiment-grade-scatter.test.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { ChakraProvider } from '@chakra-ui/react';
+import { theme } from '../../../src/config/theme';
+import { SentimentGradeScatter } from '../../../src/components/sentiment-grade-scatter';
+
+const renderWithTheme = (ui: React.ReactElement) =>
+  render(<ChakraProvider theme={theme}>{ui}</ChakraProvider>);
+
+// Mock recharts to avoid canvas issues in jest
+jest.mock('recharts', () => {
+  const OriginalModule = jest.requireActual('recharts');
+  return {
+    ...OriginalModule,
+    ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+      <div style={{ width: 500, height: 300 }}>{children}</div>
+    ),
+  };
+});
+
+describe('SentimentGradeScatter', () => {
+  it('renders fallback when no data', () => {
+    renderWithTheme(<SentimentGradeScatter data={[]} />);
+    expect(screen.getByText(/no sentiment data/i)).toBeInTheDocument();
+  });
+
+  it('renders heading when data present', () => {
+    const data = [
+      { source: 'ESPN', grade: 3.5, sentiment: 0.6 },
+    ];
+    renderWithTheme(<SentimentGradeScatter data={data} />);
+    expect(screen.getByText(/sentiment vs grade/i)).toBeInTheDocument();
+  });
+});

--- a/apps/mmd-public/test/unit/components/source-tone-chart.test.tsx
+++ b/apps/mmd-public/test/unit/components/source-tone-chart.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { ChakraProvider } from '@chakra-ui/react';
+import { theme } from '../../../src/config/theme';
+import { SourceToneChart } from '../../../src/components/source-tone-chart';
+
+const renderWithTheme = (ui: React.ReactElement) =>
+  render(<ChakraProvider theme={theme}>{ui}</ChakraProvider>);
+
+// Mock recharts to avoid canvas issues in jest
+jest.mock('recharts', () => {
+  const OriginalModule = jest.requireActual('recharts');
+  return {
+    ...OriginalModule,
+    ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+      <div style={{ width: 500, height: 300 }}>{children}</div>
+    ),
+  };
+});
+
+describe('SourceToneChart', () => {
+  it('renders fallback when no data', () => {
+    renderWithTheme(<SourceToneChart data={[]} />);
+    expect(screen.getByText(/no sentiment data/i)).toBeInTheDocument();
+  });
+
+  it('renders chart heading with data', () => {
+    const data = [
+      { source: 'ESPN', sentiment: 0.65 },
+      { source: 'CBS Sports', sentiment: -0.2 },
+    ];
+    renderWithTheme(<SourceToneChart data={data} />);
+    expect(screen.getByText(/source tone/i)).toBeInTheDocument();
+  });
+});

--- a/apps/mmd-public/test/unit/components/word-cloud.test.tsx
+++ b/apps/mmd-public/test/unit/components/word-cloud.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { ChakraProvider } from '@chakra-ui/react';
+import { theme } from '../../../src/config/theme';
+import { WordCloud } from '../../../src/components/word-cloud';
+
+const renderWithTheme = (ui: React.ReactElement) =>
+  render(<ChakraProvider theme={theme}>{ui}</ChakraProvider>);
+
+describe('WordCloud', () => {
+  it('renders fallback when keywords is empty', () => {
+    renderWithTheme(<WordCloud keywords={[]} />);
+    expect(screen.getByText(/no text analysis data/i)).toBeInTheDocument();
+  });
+
+  it('renders words with varying sizes', () => {
+    const keywords = [
+      { word: 'athletic', count: 10 },
+      { word: 'raw', count: 5 },
+      { word: 'upside', count: 1 },
+    ];
+    renderWithTheme(<WordCloud keywords={keywords} />);
+    expect(screen.getByText('athletic')).toBeInTheDocument();
+    expect(screen.getByText('raw')).toBeInTheDocument();
+    expect(screen.getByText('upside')).toBeInTheDocument();
+  });
+});

--- a/apps/mmd-public/test/unit/lib/statistics.test.ts
+++ b/apps/mmd-public/test/unit/lib/statistics.test.ts
@@ -1,0 +1,113 @@
+import {
+  calculateTeamSentiment,
+  findSentimentLeaders,
+  aggregateKeywords,
+  calculateSourceSentiments,
+} from '../../../src/lib/statistics';
+
+describe('calculateTeamSentiment', () => {
+  it('returns null when no grades have sentiment', () => {
+    const grades = [
+      { sentimentCompound: null },
+      { sentimentCompound: undefined },
+    ] as any[];
+    expect(calculateTeamSentiment(grades)).toBeNull();
+  });
+
+  it('returns average compound sentiment', () => {
+    const grades = [
+      { sentimentCompound: 0.8 },
+      { sentimentCompound: 0.2 },
+      { sentimentCompound: -0.4 },
+    ] as any[];
+    expect(calculateTeamSentiment(grades)).toBeCloseTo(0.2);
+  });
+
+  it('returns null for empty array', () => {
+    expect(calculateTeamSentiment([])).toBeNull();
+  });
+});
+
+describe('findSentimentLeaders', () => {
+  it('finds most positive and most criticized teams', () => {
+    const teams = [
+      {
+        team: { id: '1', name: 'Team A' },
+        draftGrades: [{ sentimentCompound: 0.9 }, { sentimentCompound: 0.7 }],
+      },
+      {
+        team: { id: '2', name: 'Team B' },
+        draftGrades: [{ sentimentCompound: -0.5 }, { sentimentCompound: -0.3 }],
+      },
+      {
+        team: { id: '3', name: 'Team C' },
+        draftGrades: [{ sentimentCompound: 0.1 }],
+      },
+    ] as any[];
+
+    const result = findSentimentLeaders(teams);
+    expect(result.mostPositive?.team.name).toBe('Team A');
+    expect(result.mostCriticized?.team.name).toBe('Team B');
+  });
+
+  it('returns null leaders when no sentiment data exists', () => {
+    const teams = [
+      { team: { id: '1', name: 'Team A' }, draftGrades: [{ sentimentCompound: null }] },
+    ] as any[];
+
+    const result = findSentimentLeaders(teams);
+    expect(result.mostPositive).toBeNull();
+    expect(result.mostCriticized).toBeNull();
+  });
+});
+
+describe('aggregateKeywords', () => {
+  it('merges keywords across grades and sorts by count', () => {
+    const grades = [
+      { keywords: [{ word: 'solid', count: 3 }, { word: 'athletic', count: 2 }] },
+      { keywords: [{ word: 'solid', count: 1 }, { word: 'raw', count: 4 }] },
+    ] as any[];
+
+    const result = aggregateKeywords(grades);
+    // Both 'solid' and 'raw' have count 4; verify counts are correct
+    expect(result).toHaveLength(3);
+    expect(result.find(k => k.word === 'solid')).toEqual({ word: 'solid', count: 4 });
+    expect(result.find(k => k.word === 'raw')).toEqual({ word: 'raw', count: 4 });
+    expect(result.find(k => k.word === 'athletic')).toEqual({ word: 'athletic', count: 2 });
+    // Athletic should be last (lowest count)
+    expect(result[2]).toEqual({ word: 'athletic', count: 2 });
+  });
+
+  it('returns empty array when no keywords', () => {
+    const grades = [{ keywords: null }, { keywords: undefined }] as any[];
+    expect(aggregateKeywords(grades)).toEqual([]);
+  });
+});
+
+describe('calculateSourceSentiments', () => {
+  it('calculates average sentiment per source', () => {
+    const teams = [
+      {
+        team: { id: '1' },
+        draftGrades: [
+          { sentimentCompound: 0.8, sourceArticle: { source: { name: 'ESPN', slug: 'espn' } } },
+          { sentimentCompound: 0.2, sourceArticle: { source: { name: 'CBS', slug: 'cbs' } } },
+        ],
+      },
+      {
+        team: { id: '2' },
+        draftGrades: [
+          { sentimentCompound: 0.4, sourceArticle: { source: { name: 'ESPN', slug: 'espn' } } },
+          { sentimentCompound: -0.6, sourceArticle: { source: { name: 'CBS', slug: 'cbs' } } },
+        ],
+      },
+    ] as any[];
+
+    const result = calculateSourceSentiments(teams);
+    const espn = result.find(s => s.source.name === 'ESPN');
+    const cbs = result.find(s => s.source.name === 'CBS');
+
+    expect(espn?.avgSentiment).toBeCloseTo(0.6);
+    expect(cbs?.avgSentiment).toBeCloseTo(-0.2);
+  });
+});


### PR DESCRIPTION
## Summary
- Add sentiment analysis columns (compound, positive, negative, neutral) and keyword extraction to DraftClassGrade entity
- Add seed step that calls the text-analysis-service to analyze draft grade article text and store sentiment/keywords
- Build 5 new visualization components: SentimentBadge, WordCloud, SourceToneChart, SentimentGradeScatter, and sentiment utility functions
- Integrate sentiment data into home dashboard (hero stats for most positive/criticized teams, league-wide source tone chart, sparkline sentiment dots)
- Integrate sentiment data into team detail page (per-source tone comparison, grade vs sentiment scatter, keyword word cloud, sentiment badges on grades)

## Test plan
- [x] All existing tests pass (39 draft-api, 20 mmd-public)
- [x] Lint and build pass for all packages
- [x] Seed runs idempotently (`npm run seed -- --step text-analysis --year 2024`)
- [x] Home page 2024: hero stats show "Most Positive Buzz" (Buffalo Bills) and "Most Criticized" (Seattle Seahawks)
- [x] Home page 2024: League-Wide Source Tone chart renders with all sources
- [x] Home page 2024: Sparkline dots colored by sentiment in TREND column
- [x] Team detail page 2024: Key Terms word cloud, Source Tone Comparison, Sentiment vs Grade scatter all render
- [x] Team detail page 2024: SentimentBadge shows next to each grade
- [x] Years without sentiment data (e.g. 2025) gracefully hide sentiment components