### PR TITLE
Codebase review fixes: migrations, scheduler, and auth/data correctness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ dist
 tmp
 /out-tsc
 
+# Turbo
+.turbo
+
 # dependencies
 node_modules
 
@@ -45,7 +48,7 @@ Thumbs.db
 .next
 out
 
-// Env files
+# Env files
 .env
 .env.*
 !.env.example

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,23 +1,7 @@
 # Project Guidelines
 
-## Monorepo
-npm workspaces + Turbo. Run tasks with:
-```
-npx turbo run <lint|build|test> [--filter=@mmd/<package>]
-```
-Always exclude the Python service when running across all packages — it requires a local Poetry setup:
-```
-npx turbo run lint build test --filter=!@mmd/text-analysis-service --filter=!@mmd/text-analysis-service-e2e
-```
+Project guidelines live in a single source of truth: [CLAUDE.md](./CLAUDE.md).
 
-## Apps
-- `draft-api` — Express + TypeORM, deployed on Railway
-- `admin` — Next.js admin dashboard, deployed on Railway
-- `mmd-public` — Next.js public site, deployed on Railway
-- `data-collector` — Python data pipeline (Poetry)
-- `libs/visualizations` — shared React component library (Vite)
-
-## Conventions
-- Unused parameters: prefix with `_` (ESLint `argsIgnorePattern: "^_"`)
-- Chakra UI component tests need `<ChakraProvider theme={theme}>` wrapper — missing it causes theme token lookup errors
-- `apiClient` in mmd-public already unwraps `response.data` via interceptor; don't double-unwrap
+Read that file for monorepo/build commands, the app inventory, local dev setup,
+and coding conventions. It applies to all agents working in this repo, not just
+Claude.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,8 @@ npx turbo run lint build test --filter=!@mmd/text-analysis-service --filter=!@mm
 - `draft-api` — Express + TypeORM, deployed on Railway (port 4000)
 - `admin` — Next.js admin dashboard, deployed on Railway (port 3001)
 - `mmd-public` — Next.js public site, deployed on Railway (port 3000)
-- `data-collector` — Python data pipeline (uv)
+- `text-analysis-service` — FastAPI sentiment/word analysis (uv, Python 3.9-3.10)
+- `data-collector` — Node.js data pipeline (Puppeteer + Cheerio + Claude SDK)
 - `libs/visualizations` — shared React component library (Vite)
 
 ## Local Dev Environment

--- a/README.md
+++ b/README.md
@@ -45,7 +45,10 @@ npm run db:seed -- --year 2024
 npm run db:seed -- --step teams
 ```
 
-The database schema is auto-created on first connection (`synchronize: true`).
+The schema is managed by TypeORM migrations, which run automatically on API
+startup. On a fresh database the initial migration creates the full schema. See
+[docs/database-migrations.md](docs/database-migrations.md) for the migration
+workflow.
 
 ### 4. Start the apps
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ NFL draft grade aggregation and analysis.
 - `mmd-public` — Next.js public site (port 3000)
 - `admin` — Next.js admin dashboard (port 3001)
 - `text-analysis-service` — FastAPI sentiment/word analysis (uv, Python 3.9-3.10)
-- `data-collector` — Python data pipeline (Poetry)
+- `data-collector` — Node.js data pipeline (Puppeteer + Cheerio + Claude SDK)
 - `libs/visualizations` — shared React component library (Vite)
 
 ## Local Development

--- a/apps/draft-api/.env.example
+++ b/apps/draft-api/.env.example
@@ -8,3 +8,12 @@ ADMIN_EMAIL=admin@localhost
 ADMIN_PASSWORD=admin123
 
 CLIENT_ORIGIN=http://localhost:3000,http://localhost:3001
+
+# Data imports
+# Year of the data-collector file to import (apps/data-collector/data/<YEAR>_draft_data.json).
+# Defaults to the current year.
+DRAFT_IMPORT_YEAR=2025
+# Set to false to skip the 5am ET daily import job (e.g. local dev or non-primary replicas).
+DAILY_IMPORT_ENABLED=true
+# Optional Slack Incoming Webhook URL; alerts are posted here when an import fails.
+DATA_IMPORT_ALERT_WEBHOOK=

--- a/apps/draft-api/.env.example
+++ b/apps/draft-api/.env.example
@@ -1,6 +1,13 @@
 DATABASE_URL=postgresql://mmd:mmd@localhost:5434/mmd_dev
 PORT=4000
 
+# Schema is managed by TypeORM migrations (see docs/database-migrations.md).
+# Pending migrations run on startup; set RUN_MIGRATIONS=false to apply them
+# separately. DB_SYNCHRONIZE=true re-enables entity auto-sync (local throwaway
+# DBs only — never against data you care about).
+RUN_MIGRATIONS=true
+DB_SYNCHRONIZE=false
+
 JWT_SECRET_KEY=local-dev-secret-key-change-in-production
 
 ADMIN_USERNAME=admin

--- a/apps/draft-api/.env.example
+++ b/apps/draft-api/.env.example
@@ -20,7 +20,9 @@ CLIENT_ORIGIN=http://localhost:3000,http://localhost:3001
 # Year of the data-collector file to import (apps/data-collector/data/<YEAR>_draft_data.json).
 # Defaults to the current year.
 DRAFT_IMPORT_YEAR=2025
-# Set to false to skip the 5am ET daily import job (e.g. local dev or non-primary replicas).
-DAILY_IMPORT_ENABLED=true
+# Set to true to enable the 5am ET daily import job. Off by default: the import
+# needs its data file present in the deploy and a single runner (no multi-replica
+# coordination yet), so enable it only on one instance once those are in place.
+DAILY_IMPORT_ENABLED=false
 # Optional Slack Incoming Webhook URL; alerts are posted here when an import fails.
 DATA_IMPORT_ALERT_WEBHOOK=

--- a/apps/draft-api/package.json
+++ b/apps/draft-api/package.json
@@ -8,6 +8,11 @@
     "dev": "ts-node --project tsconfig.app.json src/main.ts",
     "seed": "ts-node --project tsconfig.app.json src/commands/seed.ts",
     "db:seed-all": "ts-node --project tsconfig.app.json src/commands/seed-all.ts",
+    "typeorm": "TS_NODE_PROJECT=tsconfig.app.json typeorm-ts-node-commonjs -d src/database/index.ts",
+    "migration:generate": "npm run typeorm -- migration:generate",
+    "migration:run": "npm run typeorm -- migration:run",
+    "migration:revert": "npm run typeorm -- migration:revert",
+    "migration:show": "npm run typeorm -- migration:show",
     "lint": "eslint src/",
     "test": "jest"
   }

--- a/apps/draft-api/src/commands/seed-all.ts
+++ b/apps/draft-api/src/commands/seed-all.ts
@@ -14,7 +14,8 @@ async function main() {
   console.log('\n=== Seed All: Full Database Population ===\n');
 
   await AppDataSource.initialize();
-  console.log('Database connected.\n');
+  await AppDataSource.runMigrations();
+  console.log('Database connected (migrations applied).\n');
 
   const results: SeedResult[] = [];
 

--- a/apps/draft-api/src/commands/seed.ts
+++ b/apps/draft-api/src/commands/seed.ts
@@ -53,7 +53,8 @@ async function main() {
   console.log(`Steps: ${steps ? steps.join(', ') : 'all'}\n`);
 
   await AppDataSource.initialize();
-  console.log('Database connected.\n');
+  await AppDataSource.runMigrations();
+  console.log('Database connected (migrations applied).\n');
 
   const results: SeedResult[] = [];
   const allSteps: StepName[] = ['teams', 'players', 'draft-classes', 'grades', 'player-grades'];

--- a/apps/draft-api/src/database/index.ts
+++ b/apps/draft-api/src/database/index.ts
@@ -3,6 +3,7 @@ import {
   DefaultNamingStrategy,
   NamingStrategyInterface,
 } from 'typeorm';
+import { join } from 'path';
 import { User } from './models/user';
 import { initAdmin } from './utils/initAdmin';
 import { Team } from './models/team';
@@ -50,6 +51,11 @@ class SnakeNamingStrategy
   }
 }
 
+// Resolve migration/subscriber globs relative to this file so they work both
+// under ts-node (src/**/*.ts) and from the compiled build (dist/**/*.js).
+const migrationsGlob = join(__dirname, 'migrations', '*.{ts,js}');
+const subscribersGlob = join(__dirname, 'subscribers', '*.{ts,js}');
+
 export const AppDataSource: DataSource = new DataSource({
   type: 'postgres',
   url: process.env.DATABASE_URL,
@@ -68,17 +74,34 @@ export const AppDataSource: DataSource = new DataSource({
     DataImportLog,
     DraftSession,
   ],
-  synchronize: true,
+  // Schema is managed by migrations. Leave synchronize off; set DB_SYNCHRONIZE=true
+  // only for throwaway local experiments where you don't care about the schema.
+  synchronize: process.env.DB_SYNCHRONIZE === 'true',
   logging: true,
-  migrations: ['src/database/migrations/*.ts'],
-  subscribers: ['src/database/subscribers/*.ts'],
+  migrations: [migrationsGlob],
+  subscribers: [subscribersGlob],
   namingStrategy: new SnakeNamingStrategy(),
 });
+
+// Pending migrations run automatically on startup. Set RUN_MIGRATIONS=false to
+// disable (e.g. when migrations are applied as a separate deploy/release step).
+const shouldRunMigrations = process.env.RUN_MIGRATIONS !== 'false';
 
 export const initializeDatabase = async () => {
   try {
     await AppDataSource.initialize();
     console.log('Database initialized');
+
+    if (shouldRunMigrations) {
+      const executed = await AppDataSource.runMigrations();
+      console.log(
+        executed.length
+          ? `Ran ${executed.length} migration(s): ${executed
+              .map((migration) => migration.name)
+              .join(', ')}`
+          : 'No pending migrations',
+      );
+    }
 
     await initAdmin();
 

--- a/apps/draft-api/src/database/migrations/1780856836627-InitialSchema.ts
+++ b/apps/draft-api/src/database/migrations/1780856836627-InitialSchema.ts
@@ -1,0 +1,85 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class InitialSchema1780856836627 implements MigrationInterface {
+    name = 'InitialSchema1780856836627'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE EXTENSION IF NOT EXISTS "uuid-ossp"`);
+        await queryRunner.query(`CREATE TABLE "users" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "username" character varying NOT NULL, "password" character varying NOT NULL, "email" character varying NOT NULL, "is_admin" boolean NOT NULL DEFAULT false, "last_login" TIMESTAMP, "created_at" TIMESTAMP NOT NULL DEFAULT now(), "updated_at" TIMESTAMP NOT NULL DEFAULT now(), "deleted_at" TIMESTAMP, CONSTRAINT "UQ_772886e2f1f47b9ceb04a06e203" UNIQUE ("username", "email"), CONSTRAINT "PK_a3ffb1c0c8416b9fc6f907b7433" PRIMARY KEY ("id"))`);
+        await queryRunner.query(`CREATE TABLE "sources" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "name" character varying NOT NULL, "slug" character varying NOT NULL, "base_url" character varying NOT NULL, "created_at" TIMESTAMP NOT NULL DEFAULT now(), "updated_at" TIMESTAMP NOT NULL DEFAULT now(), "deleted_at" TIMESTAMP, CONSTRAINT "PK_85523beafe5a2a6b90b02096443" PRIMARY KEY ("id"))`);
+        await queryRunner.query(`CREATE TYPE "public"."data_import_logs_status_enum" AS ENUM('pending', 'published', 'failed')`);
+        await queryRunner.query(`CREATE TYPE "public"."data_import_logs_source_enum" AS ENUM('daily', 'manual')`);
+        await queryRunner.query(`CREATE TABLE "data_import_logs" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "status" "public"."data_import_logs_status_enum" NOT NULL, "started_at" TIMESTAMP NOT NULL DEFAULT now(), "completed_at" TIMESTAMP, "error_summary" text, "player_count" integer NOT NULL DEFAULT '0', "ranking_count" integer NOT NULL DEFAULT '0', "source" "public"."data_import_logs_source_enum" NOT NULL, "data_version_id" uuid, CONSTRAINT "PK_01a5b6d0505ecb9f4767de9463f" PRIMARY KEY ("id"))`);
+        await queryRunner.query(`CREATE TYPE "public"."data_versions_source_enum" AS ENUM('daily', 'manual')`);
+        await queryRunner.query(`CREATE TYPE "public"."data_versions_status_enum" AS ENUM('pending', 'published', 'failed')`);
+        await queryRunner.query(`CREATE TABLE "data_versions" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "source" "public"."data_versions_source_enum" NOT NULL, "status" "public"."data_versions_status_enum" NOT NULL, "is_active" boolean NOT NULL DEFAULT false, "published_at" TIMESTAMP, "player_count" integer NOT NULL DEFAULT '0', "ranking_count" integer NOT NULL DEFAULT '0', "created_at" TIMESTAMP NOT NULL DEFAULT now(), "updated_at" TIMESTAMP NOT NULL DEFAULT now(), CONSTRAINT "PK_5cc253399d3471daa779658886a" PRIMARY KEY ("id"))`);
+        await queryRunner.query(`CREATE TABLE "player_rankings" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "year" integer NOT NULL, "overall_rank" integer NOT NULL, "position_rank" integer NOT NULL, "position" character varying NOT NULL, "notes" character varying NOT NULL, "created_at" TIMESTAMP NOT NULL DEFAULT now(), "updated_at" TIMESTAMP NOT NULL DEFAULT now(), "player_id" uuid, "data_version_id" uuid, "source_article_id" uuid, CONSTRAINT "PK_d626ed3b65fcf9c550a3a8d6eaa" PRIMARY KEY ("id"))`);
+        await queryRunner.query(`CREATE TABLE "draft_pick_trades" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "trade_date" date, "trade_details" character varying, "created_at" TIMESTAMP NOT NULL DEFAULT now(), "updated_at" TIMESTAMP NOT NULL DEFAULT now(), "draft_pick_id" uuid, "from_team_id" uuid, "to_team_id" uuid, CONSTRAINT "PK_d150380bedd8eaf6d46ab4c2863" PRIMARY KEY ("id"))`);
+        await queryRunner.query(`CREATE TABLE "draft_picks" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "year" integer NOT NULL, "round" integer NOT NULL, "pick_number" integer NOT NULL, "created_at" TIMESTAMP NOT NULL DEFAULT now(), "updated_at" TIMESTAMP NOT NULL DEFAULT now(), "original_team_id" uuid, "current_team_id" uuid, "player_id" uuid, CONSTRAINT "unique_draft_pick" UNIQUE ("year", "round", "pick_number"), CONSTRAINT "REL_808f73cc7ad056f24d53e7a64b" UNIQUE ("player_id"), CONSTRAINT "PK_d39b2bc8afb5ccdb05b92edcf63" PRIMARY KEY ("id"))`);
+        await queryRunner.query(`CREATE TABLE "players" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "name" character varying NOT NULL, "position" character varying NOT NULL, "date_of_birth" TIMESTAMP, "college" character varying, "height" integer, "weight" integer, "arm_length" numeric(5,3), "hand_size" numeric(5,3), "forty_yard_dash" numeric(5,3), "ten_yard_split" numeric(5,3), "twenty_yard_split" numeric(5,3), "twenty_yard_shuttle" numeric(5,3), "three_cone_drill" numeric(5,3), "vertical_jump" numeric(5,3), "broad_jump" numeric(6,3), "bench_press" integer, "hometown" character varying, "created_at" TIMESTAMP NOT NULL DEFAULT now(), "updated_at" TIMESTAMP NOT NULL DEFAULT now(), "deleted_at" TIMESTAMP, "data_version_id" uuid, CONSTRAINT "PK_de22b8fdeee0c33ab55ae71da3b" PRIMARY KEY ("id"))`);
+        await queryRunner.query(`CREATE TABLE "player_grades" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "grade" character varying, "grade_numeric" double precision, "text" character varying, "created_at" TIMESTAMP NOT NULL DEFAULT now(), "updated_at" TIMESTAMP NOT NULL DEFAULT now(), "deleted_at" TIMESTAMP, "draft_pick_id" uuid, "player_id" uuid, "team_id" uuid, "source_article_id" uuid, CONSTRAINT "PK_312f4734cd245424738ab9cf2c6" PRIMARY KEY ("id"))`);
+        await queryRunner.query(`CREATE TABLE "source_articles" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "year" integer NOT NULL, "title" character varying NOT NULL, "url" character varying NOT NULL, "publication_date" TIMESTAMP, "created_at" TIMESTAMP NOT NULL DEFAULT now(), "updated_at" TIMESTAMP NOT NULL DEFAULT now(), "deleted_at" TIMESTAMP, "source_id" uuid, CONSTRAINT "UQ_2788b4ffe99e13e1a8521cee038" UNIQUE ("year", "url"), CONSTRAINT "PK_a2f55b3d27e5481002bce7ad0a8" PRIMARY KEY ("id"))`);
+        await queryRunner.query(`CREATE TABLE "draft_class_grades" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "grade" character varying NOT NULL, "grade_numeric" double precision NOT NULL, "year" integer NOT NULL, "text" character varying, "created_at" TIMESTAMP NOT NULL DEFAULT now(), "updated_at" TIMESTAMP NOT NULL DEFAULT now(), "deleted_at" TIMESTAMP, "team_id" uuid, "source_article_id" uuid, CONSTRAINT "PK_074b69e069063ea5c7402aabe9a" PRIMARY KEY ("id"))`);
+        await queryRunner.query(`CREATE TABLE "teams" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "name" character varying NOT NULL, "location" character varying NOT NULL, "nickname" character varying NOT NULL, "abbreviation" character varying NOT NULL, "slug" character varying NOT NULL, "conference" character varying NOT NULL, "division" character varying NOT NULL, "logo" character varying NOT NULL, "colors" text NOT NULL, "created_at" TIMESTAMP NOT NULL DEFAULT now(), "updated_at" TIMESTAMP NOT NULL DEFAULT now(), "deleted_at" TIMESTAMP, CONSTRAINT "UQ_de8536da4945fe980f4a61900d3" UNIQUE ("slug"), CONSTRAINT "PK_7e5523774a38b08a6236d322403" PRIMARY KEY ("id"))`);
+        await queryRunner.query(`CREATE TABLE "draft_sessions" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "created_at" TIMESTAMP NOT NULL DEFAULT now(), "updated_at" TIMESTAMP NOT NULL DEFAULT now(), "data_version_id" uuid, CONSTRAINT "PK_8a6a37b27c812109f213bba5956" PRIMARY KEY ("id"))`);
+        await queryRunner.query(`ALTER TABLE "data_import_logs" ADD CONSTRAINT "FK_d6f837ac53ba78314d4c72fb06f" FOREIGN KEY ("data_version_id") REFERENCES "data_versions"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "player_rankings" ADD CONSTRAINT "FK_6944e3e048e0160488cbe437587" FOREIGN KEY ("player_id") REFERENCES "players"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "player_rankings" ADD CONSTRAINT "FK_d2c8e38d8327d06fd124e663a03" FOREIGN KEY ("data_version_id") REFERENCES "data_versions"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "player_rankings" ADD CONSTRAINT "FK_a854e38a0111b0faf51cb45e024" FOREIGN KEY ("source_article_id") REFERENCES "source_articles"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "draft_pick_trades" ADD CONSTRAINT "FK_0e23a73e9cb59158b6a5a546858" FOREIGN KEY ("draft_pick_id") REFERENCES "draft_picks"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "draft_pick_trades" ADD CONSTRAINT "FK_8234a4d19f05b837e029faf5f30" FOREIGN KEY ("from_team_id") REFERENCES "teams"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "draft_pick_trades" ADD CONSTRAINT "FK_169c7a2863f0115ca3cf86bac7f" FOREIGN KEY ("to_team_id") REFERENCES "teams"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "draft_picks" ADD CONSTRAINT "FK_84c5bfea604324c04aa25cc7071" FOREIGN KEY ("original_team_id") REFERENCES "teams"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "draft_picks" ADD CONSTRAINT "FK_e488715401e882f29882f324e37" FOREIGN KEY ("current_team_id") REFERENCES "teams"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "draft_picks" ADD CONSTRAINT "FK_808f73cc7ad056f24d53e7a64b1" FOREIGN KEY ("player_id") REFERENCES "players"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "players" ADD CONSTRAINT "FK_abc007e6e5b7192700ebf768d57" FOREIGN KEY ("data_version_id") REFERENCES "data_versions"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "player_grades" ADD CONSTRAINT "FK_82286c3c7d52ce66f19c203547e" FOREIGN KEY ("draft_pick_id") REFERENCES "draft_picks"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "player_grades" ADD CONSTRAINT "FK_9ebfd46c22acfe721aa01503832" FOREIGN KEY ("player_id") REFERENCES "players"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "player_grades" ADD CONSTRAINT "FK_0d8523f0a6e109baf1a9301913c" FOREIGN KEY ("team_id") REFERENCES "teams"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "player_grades" ADD CONSTRAINT "FK_ed98eb4a4ff5186738ede24960b" FOREIGN KEY ("source_article_id") REFERENCES "source_articles"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "source_articles" ADD CONSTRAINT "FK_b7bd147a44dc755efb628c3e8ce" FOREIGN KEY ("source_id") REFERENCES "sources"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "draft_class_grades" ADD CONSTRAINT "FK_4d71b5f5010177be54dbba713b6" FOREIGN KEY ("team_id") REFERENCES "teams"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "draft_class_grades" ADD CONSTRAINT "FK_0f1d8c8ee26236f5e7d59ed0c02" FOREIGN KEY ("source_article_id") REFERENCES "source_articles"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "draft_sessions" ADD CONSTRAINT "FK_46626836aa20fcbcfc87151e952" FOREIGN KEY ("data_version_id") REFERENCES "data_versions"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "draft_sessions" DROP CONSTRAINT "FK_46626836aa20fcbcfc87151e952"`);
+        await queryRunner.query(`ALTER TABLE "draft_class_grades" DROP CONSTRAINT "FK_0f1d8c8ee26236f5e7d59ed0c02"`);
+        await queryRunner.query(`ALTER TABLE "draft_class_grades" DROP CONSTRAINT "FK_4d71b5f5010177be54dbba713b6"`);
+        await queryRunner.query(`ALTER TABLE "source_articles" DROP CONSTRAINT "FK_b7bd147a44dc755efb628c3e8ce"`);
+        await queryRunner.query(`ALTER TABLE "player_grades" DROP CONSTRAINT "FK_ed98eb4a4ff5186738ede24960b"`);
+        await queryRunner.query(`ALTER TABLE "player_grades" DROP CONSTRAINT "FK_0d8523f0a6e109baf1a9301913c"`);
+        await queryRunner.query(`ALTER TABLE "player_grades" DROP CONSTRAINT "FK_9ebfd46c22acfe721aa01503832"`);
+        await queryRunner.query(`ALTER TABLE "player_grades" DROP CONSTRAINT "FK_82286c3c7d52ce66f19c203547e"`);
+        await queryRunner.query(`ALTER TABLE "players" DROP CONSTRAINT "FK_abc007e6e5b7192700ebf768d57"`);
+        await queryRunner.query(`ALTER TABLE "draft_picks" DROP CONSTRAINT "FK_808f73cc7ad056f24d53e7a64b1"`);
+        await queryRunner.query(`ALTER TABLE "draft_picks" DROP CONSTRAINT "FK_e488715401e882f29882f324e37"`);
+        await queryRunner.query(`ALTER TABLE "draft_picks" DROP CONSTRAINT "FK_84c5bfea604324c04aa25cc7071"`);
+        await queryRunner.query(`ALTER TABLE "draft_pick_trades" DROP CONSTRAINT "FK_169c7a2863f0115ca3cf86bac7f"`);
+        await queryRunner.query(`ALTER TABLE "draft_pick_trades" DROP CONSTRAINT "FK_8234a4d19f05b837e029faf5f30"`);
+        await queryRunner.query(`ALTER TABLE "draft_pick_trades" DROP CONSTRAINT "FK_0e23a73e9cb59158b6a5a546858"`);
+        await queryRunner.query(`ALTER TABLE "player_rankings" DROP CONSTRAINT "FK_a854e38a0111b0faf51cb45e024"`);
+        await queryRunner.query(`ALTER TABLE "player_rankings" DROP CONSTRAINT "FK_d2c8e38d8327d06fd124e663a03"`);
+        await queryRunner.query(`ALTER TABLE "player_rankings" DROP CONSTRAINT "FK_6944e3e048e0160488cbe437587"`);
+        await queryRunner.query(`ALTER TABLE "data_import_logs" DROP CONSTRAINT "FK_d6f837ac53ba78314d4c72fb06f"`);
+        await queryRunner.query(`DROP TABLE "draft_sessions"`);
+        await queryRunner.query(`DROP TABLE "teams"`);
+        await queryRunner.query(`DROP TABLE "draft_class_grades"`);
+        await queryRunner.query(`DROP TABLE "source_articles"`);
+        await queryRunner.query(`DROP TABLE "player_grades"`);
+        await queryRunner.query(`DROP TABLE "players"`);
+        await queryRunner.query(`DROP TABLE "draft_picks"`);
+        await queryRunner.query(`DROP TABLE "draft_pick_trades"`);
+        await queryRunner.query(`DROP TABLE "player_rankings"`);
+        await queryRunner.query(`DROP TABLE "data_versions"`);
+        await queryRunner.query(`DROP TYPE "public"."data_versions_status_enum"`);
+        await queryRunner.query(`DROP TYPE "public"."data_versions_source_enum"`);
+        await queryRunner.query(`DROP TABLE "data_import_logs"`);
+        await queryRunner.query(`DROP TYPE "public"."data_import_logs_source_enum"`);
+        await queryRunner.query(`DROP TYPE "public"."data_import_logs_status_enum"`);
+        await queryRunner.query(`DROP TABLE "sources"`);
+        await queryRunner.query(`DROP TABLE "users"`);
+    }
+
+}

--- a/apps/draft-api/src/database/utils/initAdmin.ts
+++ b/apps/draft-api/src/database/utils/initAdmin.ts
@@ -18,7 +18,14 @@ export async function initAdmin() {
     const existingAdmin = await userService.getUserByUsername(adminUsername);
 
     if (existingAdmin) {
-      console.log('Admin user already exists');
+      // Self-heal: ensure the configured admin actually has admin rights. This
+      // recovers accounts created before createUser honored the isAdmin flag.
+      if (!existingAdmin.isAdmin) {
+        await userService.updateUser(existingAdmin.id, { isAdmin: true });
+        console.log('Existing admin user promoted to admin');
+      } else {
+        console.log('Admin user already exists');
+      }
       return;
     }
 

--- a/apps/draft-api/src/database/utils/initAdmin.ts
+++ b/apps/draft-api/src/database/utils/initAdmin.ts
@@ -21,8 +21,16 @@ export async function initAdmin() {
       // Self-heal: ensure the configured admin actually has admin rights. This
       // recovers accounts created before createUser honored the isAdmin flag.
       if (!existingAdmin.isAdmin) {
-        await userService.updateUser(existingAdmin.id, { isAdmin: true });
-        console.log('Existing admin user promoted to admin');
+        const promoted = await userService.updateUser(existingAdmin.id, {
+          isAdmin: true,
+        });
+        if (promoted?.isAdmin) {
+          console.log('Existing admin user promoted to admin');
+        } else {
+          // updateUser swallows errors and returns null; surface the failure
+          // instead of falsely reporting success.
+          console.error('Failed to promote existing admin user to admin');
+        }
       } else {
         console.log('Admin user already exists');
       }

--- a/apps/draft-api/src/jobs/daily-data-import.job.ts
+++ b/apps/draft-api/src/jobs/daily-data-import.job.ts
@@ -1,0 +1,70 @@
+import cron, { type ScheduledTask } from 'node-cron';
+import { DataVersionStatus } from '../database/models/data-version';
+import { DataImportService } from '../services/data-import-service';
+
+// Run every day at 5:00am Eastern, after overnight data-collector scrapes have
+// landed. node-cron interprets the schedule in the configured timezone.
+const DAILY_IMPORT_SCHEDULE = '0 5 * * *';
+const DAILY_IMPORT_TIMEZONE = 'America/New_York';
+
+const LOG_PREFIX = '[daily-data-import]';
+
+/**
+ * Whether the scheduled import should run in this process. Defaults to enabled.
+ * Set DAILY_IMPORT_ENABLED=false to skip scheduling — useful for local dev and
+ * for any replica that should not own the daily import.
+ */
+function isEnabled(): boolean {
+  return process.env.DAILY_IMPORT_ENABLED !== 'false';
+}
+
+async function runDailyImport(): Promise<void> {
+  console.log(`${LOG_PREFIX} Starting scheduled data import`);
+
+  // Instantiate per run so the service binds to the initialized AppDataSource.
+  const dataImportService = new DataImportService();
+
+  try {
+    const result = await dataImportService.runScheduledImport();
+
+    if (result.status === DataVersionStatus.Failed) {
+      console.error(
+        `${LOG_PREFIX} Import failed for version ${result.dataVersionId}: ${result.errorSummary}`,
+      );
+      return;
+    }
+
+    console.log(
+      `${LOG_PREFIX} Published version ${result.dataVersionId} ` +
+        `(${result.playerCount} players, ${result.rankingCount} rankings)`,
+    );
+  } catch (error) {
+    // runScheduledImport handles expected failures internally; this guards
+    // against unexpected throws so the cron task never crashes the process.
+    console.error(`${LOG_PREFIX} Scheduled import threw:`, error);
+  }
+}
+
+/**
+ * Registers the daily data-import cron job. Call once, after the database has
+ * been initialized. Returns the scheduled task (or null when disabled) so
+ * callers can stop it if needed (e.g. graceful shutdown, tests).
+ */
+export function scheduleDailyDataImport(): ScheduledTask | null {
+  if (!isEnabled()) {
+    console.log(
+      `${LOG_PREFIX} Scheduling disabled (DAILY_IMPORT_ENABLED=false)`,
+    );
+    return null;
+  }
+
+  const task = cron.schedule(DAILY_IMPORT_SCHEDULE, runDailyImport, {
+    timezone: DAILY_IMPORT_TIMEZONE,
+  });
+
+  console.log(
+    `${LOG_PREFIX} Scheduled daily import at "${DAILY_IMPORT_SCHEDULE}" (${DAILY_IMPORT_TIMEZONE})`,
+  );
+
+  return task;
+}

--- a/apps/draft-api/src/jobs/daily-data-import.job.ts
+++ b/apps/draft-api/src/jobs/daily-data-import.job.ts
@@ -10,12 +10,16 @@ const DAILY_IMPORT_TIMEZONE = 'America/New_York';
 const LOG_PREFIX = '[daily-data-import]';
 
 /**
- * Whether the scheduled import should run in this process. Defaults to enabled.
- * Set DAILY_IMPORT_ENABLED=false to skip scheduling — useful for local dev and
- * for any replica that should not own the daily import.
+ * Whether the scheduled import should run in this process. Disabled by default;
+ * set DAILY_IMPORT_ENABLED=true to enable.
+ *
+ * It is opt-in because the import is not yet production-ready: it reads a data
+ * file (apps/data-collector/data) that is not shipped in the deploy image, and
+ * it has no cross-replica coordination, so multiple instances would race. Enable
+ * it only on a single instance once a real data source is wired up.
  */
 function isEnabled(): boolean {
-  return process.env.DAILY_IMPORT_ENABLED !== 'false';
+  return process.env.DAILY_IMPORT_ENABLED === 'true';
 }
 
 async function runDailyImport(): Promise<void> {
@@ -53,7 +57,7 @@ async function runDailyImport(): Promise<void> {
 export function scheduleDailyDataImport(): ScheduledTask | null {
   if (!isEnabled()) {
     console.log(
-      `${LOG_PREFIX} Scheduling disabled (DAILY_IMPORT_ENABLED=false)`,
+      `${LOG_PREFIX} Scheduling disabled (set DAILY_IMPORT_ENABLED=true to enable)`,
     );
     return null;
   }

--- a/apps/draft-api/src/main.ts
+++ b/apps/draft-api/src/main.ts
@@ -19,6 +19,7 @@ import draftClassRoutes from './routes/draft-class.routes';
 import dataImportsRoutes from './routes/data-imports.routes';
 
 import { initializeDatabase } from './database';
+import { scheduleDailyDataImport } from './jobs/daily-data-import.job';
 import logger from './middleware/logger';
 import { errorHandler } from './middleware/error-handler.middleware';
 const app = express();
@@ -77,6 +78,7 @@ const port = process.env.PORT || 3333;
 
 const startServer = async () => {
   await initializeDatabase();
+  scheduleDailyDataImport();
   const server = app.listen(port, () => {
     console.log(`Listening at http://localhost:${port}/api`);
   });

--- a/apps/draft-api/src/middleware/auth.ts
+++ b/apps/draft-api/src/middleware/auth.ts
@@ -1,9 +1,11 @@
 import { Response, NextFunction } from 'express';
 import { AuthService, AuthToken } from '../services/auth-service';
+import { UsersService } from '../services/users-service';
 import { AuthenticatedRequest } from '../types';
 import { User } from '../database/models/user';
 
 const authService = new AuthService();
+const usersService = new UsersService();
 
 export const authenticate = (
   req: AuthenticatedRequest,
@@ -44,14 +46,26 @@ export const authenticate = (
   }
 };
 
-export const requireAdmin = (
+export const requireAdmin = async (
   req: AuthenticatedRequest,
   res: Response,
   next: NextFunction,
 ) => {
-  if (!req.user?.isAdmin) {
+  if (!req.user?.id) {
     return res.status(403).json({ message: 'Forbidden' });
   }
 
-  next();
+  try {
+    // Authorize against current DB state rather than trusting the JWT's isAdmin
+    // claim, so admin promotions/demotions take effect without re-login.
+    const user = await usersService.getUserById(req.user.id);
+    if (!user?.isAdmin) {
+      return res.status(403).json({ message: 'Forbidden' });
+    }
+
+    next();
+  } catch (error) {
+    console.error('Error verifying admin privileges:', error);
+    return res.status(500).json({ message: 'Internal server error' });
+  }
 };

--- a/apps/draft-api/src/routes/auth-routes.ts
+++ b/apps/draft-api/src/routes/auth-routes.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express';
 import { AuthController } from '../controllers/auth-controller';
-import { authenticate } from '../middleware/auth';
+import { authenticate, requireAdmin } from '../middleware/auth';
 
 const router = Router();
 const authController = new AuthController();
@@ -8,6 +8,8 @@ const authController = new AuthController();
 router.post('/login', authController.login);
 router.post('/logout', authController.logout);
 router.get('/me', authenticate, authController.getCurrentUser);
-router.post('/register', authController.register);
+// Admin-only: there is no public self-signup. New accounts are created by an
+// authenticated admin (or seeded via initAdmin on startup).
+router.post('/register', authenticate, requireAdmin, authController.register);
 
 export default router;

--- a/apps/draft-api/src/services/draft-summary.service.ts
+++ b/apps/draft-api/src/services/draft-summary.service.ts
@@ -28,20 +28,20 @@ export class DraftSummaryService {
         (grade) => grade.team.id === team.id,
       );
 
-      const averageGrade =
-        teamGrades.reduce((acc, grade) => acc + grade.gradeNumeric, 0) /
-        teamGrades.length;
-
       return DraftSummaryMapper.toTeamResponseDto({
         team,
         draftGrades: teamGrades,
-        averageGrade,
+        averageGrade: average(teamGrades.map((grade) => grade.gradeNumeric)),
       });
     });
 
-    const averageGrade =
-      teamDraftGrades.reduce((acc, team) => acc + team.averageGrade, 0) /
-      teamDraftGrades.length;
+    // Only teams that were actually graded count toward the league average, so
+    // an ungraded team neither drags it down nor poisons it with NaN.
+    const averageGrade = average(
+      teamDraftGrades
+        .filter((team) => team.draftGrades.length > 0)
+        .map((team) => team.averageGrade),
+    );
 
     return {
       year,
@@ -98,14 +98,22 @@ export class DraftSummaryService {
       relations: ['sourceArticle', 'sourceArticle.source'],
     });
 
-    const averageGrade =
-      draftGrades.reduce((acc, grade) => acc + grade.gradeNumeric, 0) /
-      draftGrades.length;
-
     return DraftSummaryMapper.toTeamResponseDto({
       team,
       draftGrades,
-      averageGrade,
+      averageGrade: average(draftGrades.map((grade) => grade.gradeNumeric)),
     });
   }
+}
+
+/**
+ * Mean of a list of numbers, returning 0 for an empty list so callers never
+ * produce NaN — which serializes to null and breaks number-typed API clients
+ * (e.g. the public site calls averageGrade.toFixed()).
+ */
+function average(values: number[]): number {
+  if (values.length === 0) {
+    return 0;
+  }
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
 }

--- a/apps/draft-api/src/services/users-service.ts
+++ b/apps/draft-api/src/services/users-service.ts
@@ -14,6 +14,7 @@ export class UsersService {
     user.username = data.username;
     user.email = data.email;
     user.password = await bcrypt.hash(data.password, 10);
+    user.isAdmin = data.isAdmin ?? false;
 
     return this.userRepository.save(user);
   }

--- a/apps/draft-api/test/unit/database/initAdmin.test.ts
+++ b/apps/draft-api/test/unit/database/initAdmin.test.ts
@@ -43,6 +43,10 @@ describe('initAdmin', () => {
       username: 'admin',
       isAdmin: false,
     });
+    (mockUsersService.updateUser as jest.Mock).mockResolvedValue({
+      id: 'user-1',
+      isAdmin: true,
+    });
 
     await initAdmin();
 
@@ -50,6 +54,23 @@ describe('initAdmin', () => {
       isAdmin: true,
     });
     expect(mockUsersService.createUser).not.toHaveBeenCalled();
+  });
+
+  it('logs an error when promotion fails (updateUser returns null)', async () => {
+    (mockUsersService.getUserByUsername as jest.Mock).mockResolvedValue({
+      id: 'user-1',
+      username: 'admin',
+      isAdmin: false,
+    });
+    (mockUsersService.updateUser as jest.Mock).mockResolvedValue(null);
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+    await initAdmin();
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Failed to promote existing admin user to admin',
+    );
+    errorSpy.mockRestore();
   });
 
   it('leaves an existing admin untouched', async () => {

--- a/apps/draft-api/test/unit/database/initAdmin.test.ts
+++ b/apps/draft-api/test/unit/database/initAdmin.test.ts
@@ -1,0 +1,76 @@
+import { initAdmin } from '../../../src/database/utils/initAdmin';
+import { UsersService } from '../../../src/services/users-service';
+
+jest.mock('../../../src/services/users-service');
+
+const mockUsersService = {
+  getUserByUsername: jest.fn(),
+  createUser: jest.fn(),
+  updateUser: jest.fn(),
+} as unknown as jest.Mocked<UsersService>;
+
+describe('initAdmin', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (UsersService as jest.Mock).mockImplementation(() => mockUsersService);
+    process.env = {
+      ...originalEnv,
+      ADMIN_USERNAME: 'admin',
+      ADMIN_PASSWORD: 'password123',
+      ADMIN_EMAIL: 'admin@example.com',
+    };
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it('creates a new admin with isAdmin true', async () => {
+    (mockUsersService.getUserByUsername as jest.Mock).mockResolvedValue(null);
+
+    await initAdmin();
+
+    expect(mockUsersService.createUser).toHaveBeenCalledWith(
+      expect.objectContaining({ username: 'admin', isAdmin: true }),
+    );
+  });
+
+  it('promotes an existing non-admin admin account', async () => {
+    (mockUsersService.getUserByUsername as jest.Mock).mockResolvedValue({
+      id: 'user-1',
+      username: 'admin',
+      isAdmin: false,
+    });
+
+    await initAdmin();
+
+    expect(mockUsersService.updateUser).toHaveBeenCalledWith('user-1', {
+      isAdmin: true,
+    });
+    expect(mockUsersService.createUser).not.toHaveBeenCalled();
+  });
+
+  it('leaves an existing admin untouched', async () => {
+    (mockUsersService.getUserByUsername as jest.Mock).mockResolvedValue({
+      id: 'user-1',
+      username: 'admin',
+      isAdmin: true,
+    });
+
+    await initAdmin();
+
+    expect(mockUsersService.updateUser).not.toHaveBeenCalled();
+    expect(mockUsersService.createUser).not.toHaveBeenCalled();
+  });
+
+  it('skips creation when admin env vars are missing', async () => {
+    delete process.env.ADMIN_PASSWORD;
+
+    await initAdmin();
+
+    expect(mockUsersService.getUserByUsername).not.toHaveBeenCalled();
+    expect(mockUsersService.createUser).not.toHaveBeenCalled();
+  });
+});

--- a/apps/draft-api/test/unit/middleware/auth.test.ts
+++ b/apps/draft-api/test/unit/middleware/auth.test.ts
@@ -1,10 +1,12 @@
 import { Response, NextFunction } from 'express';
 import { AuthService } from '../../../src/services/auth-service';
+import { UsersService } from '../../../src/services/users-service';
 import { AuthenticatedRequest } from '../../../src/types';
 import { User } from '../../../src/database/models/user';
 import { authenticate, requireAdmin } from '../../../src/middleware/auth';
 
 jest.mock('../../../src/services/auth-service');
+jest.mock('../../../src/services/users-service');
 
 const TEST_USER: User = {
   id: 'test-user',
@@ -101,36 +103,59 @@ describe('requireAdmin middleware', () => {
   let req: AuthenticatedRequest;
   let res: Response;
   let next: NextFunction;
+  let jsonMock: jest.Mock;
 
   beforeEach(() => {
-    req = {} as AuthenticatedRequest;
-    res = {} as Response;
+    jest.clearAllMocks();
+    req = { user: { ...TEST_USER } } as AuthenticatedRequest;
+    jsonMock = jest.fn();
+    res = { status: jest.fn().mockReturnValue({ json: jsonMock }) } as unknown as Response;
     next = jest.fn();
   });
 
-  it('should call next if user is an admin', () => {
-    req.user = {
+  it('should call next if the user is an admin in the database', async () => {
+    (UsersService.prototype.getUserById as jest.Mock).mockResolvedValue({
       ...TEST_USER,
       isAdmin: true,
-    };
+    });
 
-    requireAdmin(req, res, next);
+    await requireAdmin(req, res, next);
 
     expect(next).toHaveBeenCalled();
   });
 
-  it('should return 403 status if user is not an admin', () => {
-    req.user = {
+  it('should return 403 if the user is not an admin in the database', async () => {
+    // Even with isAdmin true on the (stale) token, the DB is the source of truth.
+    req.user = { ...TEST_USER, isAdmin: true };
+    (UsersService.prototype.getUserById as jest.Mock).mockResolvedValue({
       ...TEST_USER,
       isAdmin: false,
-    };
+    });
 
-    const jsonMock = jest.fn();
-    res.status = jest.fn().mockReturnValue({ json: jsonMock });
-
-    requireAdmin(req, res, next);
+    await requireAdmin(req, res, next);
 
     expect(res.status).toHaveBeenCalledWith(403);
     expect(jsonMock).toHaveBeenCalledWith({ message: 'Forbidden' });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('should return 403 if the user no longer exists', async () => {
+    (UsersService.prototype.getUserById as jest.Mock).mockResolvedValue(null);
+
+    await requireAdmin(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('should return 500 if the lookup throws', async () => {
+    (UsersService.prototype.getUserById as jest.Mock).mockRejectedValue(
+      new Error('db down'),
+    );
+
+    await requireAdmin(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(next).not.toHaveBeenCalled();
   });
 });

--- a/apps/draft-api/test/unit/services/draft-summary.service.test.ts
+++ b/apps/draft-api/test/unit/services/draft-summary.service.test.ts
@@ -1,0 +1,110 @@
+import { DraftSummaryService } from '../../../src/services/draft-summary.service';
+import { AppDataSource } from '../../../src/database';
+import { Team } from '../../../src/database/models/team';
+
+jest.mock('../../../src/database', () => ({
+  AppDataSource: {
+    getRepository: jest.fn(),
+  },
+}));
+
+// Minimal shapes — only the fields the service/mapper read.
+const buildTeam = (id: string, name: string) => ({
+  id,
+  name,
+  abbreviation: name.slice(0, 3).toUpperCase(),
+  logo: '',
+  colors: [] as string[],
+  conference: 'afc',
+  division: 'north',
+});
+
+const buildGrade = (teamId: string, gradeNumeric: number) => ({
+  id: `g-${teamId}-${gradeNumeric}`,
+  grade: 'B',
+  gradeNumeric,
+  year: 2024,
+  text: '',
+  team: { id: teamId },
+  sourceArticle: {
+    id: 'a1',
+    title: 'Article',
+    url: 'https://example.com',
+    source: { id: 's1', name: 'Source', slug: 'source' },
+  },
+});
+
+describe('DraftSummaryService', () => {
+  let teamRepository: { find: jest.Mock; findOneByOrFail: jest.Mock };
+  let gradeRepository: { find: jest.Mock };
+
+  beforeEach(() => {
+    teamRepository = { find: jest.fn(), findOneByOrFail: jest.fn() };
+    gradeRepository = { find: jest.fn() };
+    (AppDataSource.getRepository as jest.Mock).mockImplementation((entity) =>
+      entity === Team ? teamRepository : gradeRepository,
+    );
+  });
+
+  describe('getDraftSummary', () => {
+    it('returns averageGrade 0 (not NaN) for a team with no grades', async () => {
+      teamRepository.find.mockResolvedValue([
+        buildTeam('t1', 'Bears'),
+        buildTeam('t2', 'Lions'),
+      ]);
+      gradeRepository.find.mockResolvedValue([
+        buildGrade('t1', 8),
+        buildGrade('t1', 6),
+      ]);
+
+      const result = await new DraftSummaryService().getDraftSummary(2024);
+
+      const bears = result.teams.find((team) => team.team.id === 't1');
+      const lions = result.teams.find((team) => team.team.id === 't2');
+      expect(bears?.averageGrade).toBe(7);
+      expect(lions?.averageGrade).toBe(0);
+      expect(Number.isNaN(lions?.averageGrade)).toBe(false);
+    });
+
+    it('excludes ungraded teams from the league average', async () => {
+      teamRepository.find.mockResolvedValue([
+        buildTeam('t1', 'Bears'),
+        buildTeam('t2', 'Lions'),
+      ]);
+      gradeRepository.find.mockResolvedValue([
+        buildGrade('t1', 8),
+        buildGrade('t1', 6),
+      ]);
+
+      const result = await new DraftSummaryService().getDraftSummary(2024);
+
+      // League average is over graded teams only (Bears' 7), not (7 + 0) / 2.
+      expect(result.averageGrade).toBe(7);
+    });
+
+    it('returns league averageGrade 0 when no grades exist at all', async () => {
+      teamRepository.find.mockResolvedValue([buildTeam('t1', 'Bears')]);
+      gradeRepository.find.mockResolvedValue([]);
+
+      const result = await new DraftSummaryService().getDraftSummary(2024);
+
+      expect(result.averageGrade).toBe(0);
+      expect(result.teams[0].averageGrade).toBe(0);
+    });
+  });
+
+  describe('getTeamDraftSummary', () => {
+    it('returns averageGrade 0 for an ungraded team', async () => {
+      teamRepository.findOneByOrFail.mockResolvedValue(buildTeam('t1', 'Bears'));
+      gradeRepository.find.mockResolvedValue([]);
+
+      const result = await new DraftSummaryService().getTeamDraftSummary(
+        2024,
+        'bears',
+      );
+
+      expect(result.averageGrade).toBe(0);
+      expect(Number.isNaN(result.averageGrade)).toBe(false);
+    });
+  });
+});

--- a/apps/draft-api/test/unit/services/users-service.test.ts
+++ b/apps/draft-api/test/unit/services/users-service.test.ts
@@ -1,0 +1,50 @@
+import { UsersService } from '../../../src/services/users-service';
+import { AppDataSource } from '../../../src/database';
+import bcrypt from 'bcrypt';
+
+jest.mock('../../../src/database', () => ({
+  AppDataSource: {
+    getRepository: jest.fn(),
+  },
+}));
+jest.mock('bcrypt');
+
+describe('UsersService.createUser', () => {
+  let repository: { save: jest.Mock };
+
+  beforeEach(() => {
+    repository = { save: jest.fn((user) => Promise.resolve(user)) };
+    (AppDataSource.getRepository as jest.Mock).mockReturnValue(repository);
+    (bcrypt.hash as jest.Mock).mockResolvedValue('hashed-password');
+  });
+
+  it('persists isAdmin when it is provided', async () => {
+    const user = await new UsersService().createUser({
+      username: 'admin',
+      email: 'admin@example.com',
+      password: 'password123',
+      isAdmin: true,
+    });
+
+    expect(user.isAdmin).toBe(true);
+    expect(repository.save).toHaveBeenCalledWith(
+      expect.objectContaining({ isAdmin: true, password: 'hashed-password' }),
+    );
+  });
+
+  it('defaults isAdmin to false when omitted', async () => {
+    const user = await new UsersService().createUser({
+      username: 'regular',
+      email: 'regular@example.com',
+      password: 'password123',
+    });
+
+    expect(user.isAdmin).toBe(false);
+  });
+
+  it('throws when required fields are missing', async () => {
+    await expect(
+      new UsersService().createUser({ username: 'no-password' }),
+    ).rejects.toThrow('Missing required fields');
+  });
+});

--- a/docs/database-migrations.md
+++ b/docs/database-migrations.md
@@ -1,0 +1,107 @@
+# Database Migrations
+
+`draft-api` uses [TypeORM migrations](https://typeorm.io/migrations) to manage
+the Postgres schema. Schema changes are versioned files in
+`apps/draft-api/src/database/migrations/`, not derived from the entities at
+runtime.
+
+> Previously the app ran with `synchronize: true`, which auto-derived the schema
+> from the entities on every boot. That is convenient but unsafe for production
+> (it can silently drop columns/data). Migrations replace it.
+
+## How it works
+
+- `synchronize` is **off** by default (`DB_SYNCHRONIZE=true` re-enables it only
+  for throwaway local experiments — never in a database you care about).
+- On API startup, pending migrations run automatically
+  (`apps/draft-api/src/database/index.ts`). Set `RUN_MIGRATIONS=false` to skip
+  this (e.g. if you prefer to apply migrations as a separate deploy step).
+- The migration glob resolves relative to the compiled file, so it works under
+  both `ts-node` (`src/**/*.ts`) and the production build (`dist/**/*.js`).
+
+## Local workflow
+
+All commands run from `apps/draft-api` and read `DATABASE_URL` from your env.
+
+```bash
+# Show which migrations have run ( [X] ) vs. pending ( [ ] )
+npm run migration:show
+
+# Apply pending migrations
+npm run migration:run
+
+# Revert the most recently applied migration
+npm run migration:revert
+```
+
+### Creating a new migration
+
+1. Edit the entities under `src/database/models/`.
+2. Generate a migration by diffing the entities against your **local** database
+   (it must be up to date with all prior migrations first):
+
+   ```bash
+   npm run migration:run                       # ensure DB is current
+   npm run migration:generate -- src/database/migrations/DescriptiveName
+   ```
+
+3. Review the generated file — TypeORM diffs can be noisy (e.g. it may try to
+   re-order columns or re-create constraints). Trim anything unintended.
+4. Apply and verify it round-trips:
+
+   ```bash
+   npm run migration:run
+   npm run migration:revert   # confirm down() is correct
+   npm run migration:run
+   ```
+
+5. Commit the migration file alongside the entity change.
+
+> `migration:generate` requires a running database to diff against. Start the
+> local Postgres first: `docker compose -f docker-compose.local.yml up -d`.
+
+## Production cutover (one-time)
+
+The production database was originally built with `synchronize: true`, so all
+tables already exist but there is **no `migrations` table** recording them. If
+the new code simply runs `InitialSchema` against it, the `CREATE TABLE`
+statements will fail because the tables already exist.
+
+To reconcile, **baseline** the existing database: tell TypeORM the initial
+migration is already applied, without actually running it. Do this **once**,
+before (or as part of) the first deploy of the migrations-enabled build:
+
+```sql
+-- Run against the production database BEFORE the new build boots with
+-- RUN_MIGRATIONS enabled.
+CREATE TABLE IF NOT EXISTS "migrations" (
+  "id" SERIAL NOT NULL,
+  "timestamp" bigint NOT NULL,
+  "name" character varying NOT NULL,
+  CONSTRAINT "PK_8c82d7f526340ab734260ea46be" PRIMARY KEY ("id")
+);
+
+INSERT INTO "migrations" ("timestamp", "name")
+VALUES (1780856836627, 'InitialSchema1780856836627');
+```
+
+After this, startup migrations see `InitialSchema` as already applied and do
+nothing; every migration added later applies normally.
+
+If you'd rather avoid the auto-run race during cutover, deploy the first
+migrations build with `RUN_MIGRATIONS=false`, run the SQL above, then remove the
+flag on the next deploy.
+
+> Sanity check: the timestamp/name above must match the file in
+> `src/database/migrations/`. If you regenerate the initial migration, update
+> this SQL to match its `<timestamp>-InitialSchema` value.
+
+## Notes & follow-ups
+
+- **Multiple instances:** if `draft-api` ever runs more than one replica,
+  auto-running migrations on startup can race. Move to a single release/predeploy
+  step (`RUN_MIGRATIONS=false` on the web process + a one-off `migration:run`)
+  before scaling out.
+- The `uuid-ossp` extension is created by the initial migration
+  (`CREATE EXTENSION IF NOT EXISTS "uuid-ossp"`); the database role needs
+  permission to create it (managed Postgres usually allows this).

--- a/libs/visualizations/README.md
+++ b/libs/visualizations/README.md
@@ -1,7 +1,7 @@
-# visualizations
+# @mmd/visualizations
 
-This library was generated with [Nx](https://nx.dev).
+Shared React component library, built with [Vite](https://vitejs.dev/) (library mode + `vite-plugin-dts`).
 
 ## Running unit tests
 
-Run `nx test visualizations` to execute the unit tests via [Vitest](https://vitest.dev/).
+Run `npx turbo run test --filter=@mmd/visualizations` to execute the unit tests via [Jest](https://jestjs.io/).


### PR DESCRIPTION
## Summary

A batch of fixes and follow-ups surfaced during an architectural review of the codebase. Each commit is self-contained and independently reviewable.

### Docs
- **Fix stale references** (`ba45499`) — `data-collector` is a Node.js pipeline (Puppeteer + Cheerio + Claude SDK), not Python/Poetry; `libs/visualizations` is a Vite library tested with Jest, not Nx/Vitest. `AGENTS.md` collapsed into a pointer to `CLAUDE.md` so the two guideline files can't drift apart again (the original cause of the staleness).

### Features
- **Daily data-import scheduler** (`33974e4`) — completes phase 01-02's scheduler. The import service and manual/status endpoints already existed, but nothing ran the import on a schedule (`node-cron` was a dependency with no usage). Adds a 5am ET cron → `DataImportService.runScheduledImport`, registered after DB init. **Opt-in via `DAILY_IMPORT_ENABLED=true` (default off):** the import reads a data file that isn't shipped in the deploy image and has no multi-replica coordination, so it stays disabled until a prod data source + single-runner are in place (see follow-ups).
- **Migrations switchover** (`7a320e6`) — replaces `synchronize: true` (which silently derives the schema on every boot and can drop columns/data) with versioned TypeORM migrations. Includes a baseline `InitialSchema` migration, startup auto-run (gated by `RUN_MIGRATIONS`), a fix to the migration glob so it resolves under both ts-node and the compiled build, and `migration:generate|run|revert|show` scripts. See `docs/database-migrations.md`.

### Fixes
- **draft-summary divide-by-zero** (`6a83363`) — a team/year with no grades produced `averageGrade = sum/0 = NaN`, which serializes to `null` and breaks number-typed clients (the public site calls `averageGrade.toFixed()`). Now guarded; the league average counts only graded teams.
- **Admin `isAdmin` persistence** (`9662b39`) — `createUser` accepted `isAdmin` but never copied it, so the env-configured admin was created as a non-admin and every `requireAdmin` route 403'd. Now persisted; `initAdmin` also promotes an existing non-admin admin so already-broken databases self-heal on startup.
- **Gate `/auth/register`** (`7b0cfd5`) — the route was public and unauthenticated (anyone could create an account). There is no self-signup UI, so it now requires `authenticate + requireAdmin`.

### Review follow-up fixes (from Cursor Bugbot)
- **Seed scripts run migrations** (`c2a6594`) — `db:seed`/`db:seed-all` now run migrations after `initialize()`, so seeding a fresh DB (with `synchronize` off) creates the schema first.
- **Admin promotion surfaces failures** (`c2a6594`) — `initAdmin` checks `updateUser`'s return instead of logging success unconditionally.
- **`requireAdmin` checks the DB** (`0a38ec1`) — authorizes against current DB `isAdmin` rather than the JWT claim, so promotions/demotions take effect immediately (no re-login).
- **Scheduler default-off** (`7a0b64e`) — see above; removes the nightly file-read failure and multi-replica race by default.

## ⚠️ Deployment checklist

1. **Migrations baseline (one-time, required).** The production DB already has every table (built by the old `synchronize`) but no `migrations` table. Before this deploys with migrations auto-running, **baseline** the prod DB using the SQL in `docs/database-migrations.md` (creates the `migrations` table and records `InitialSchema` as applied), or deploy once with `RUN_MIGRATIONS=false`, run the SQL, then flip it. Otherwise the first boot will try to `CREATE TABLE` over existing tables and crash.
2. **Admin self-heal (automatic).** The existing prod admin (currently `is_admin = false`) is promoted on the next startup, and `requireAdmin` now reads live DB state — no manual step or re-login needed.
3. **New env vars (optional, sane defaults):** `RUN_MIGRATIONS`, `DB_SYNCHRONIZE`, `DAILY_IMPORT_ENABLED` (default off), `DRAFT_IMPORT_YEAR`, `DATA_IMPORT_ALERT_WEBHOOK` — documented in `apps/draft-api/.env.example`.

## Verification

- `draft-api`: lint clean, **50 tests / 11 suites** pass (up from 36/8).
- The migrations work was validated against a live Postgres 16: fresh-DB run, idempotent re-run, revert round-trip, compiled-build boot, **simulated prod baseline cutover** (no-op, no errors), and `schema:log` showed zero drift between entities and the migration.
- Admin auth validated end-to-end over HTTP: a stale `isAdmin:false` token is allowed once the DB says admin (200), and an `isAdmin:true` token is rejected the moment the DB row is demoted (403).

## Follow-ups noted but not included (out of scope)

- **Scheduler prod-readiness:** before enabling `DAILY_IMPORT_ENABLED`, the import needs (a) a real prod data source — `apps/data-collector/data` isn't in the deploy image and the scraper doesn't run in prod — and (b) a Postgres advisory lock in `DataImportService` to be safe under multiple replicas.
- **Migrations on multiple replicas:** auto-running on startup can race if `draft-api` scales beyond one instance — move to a release/predeploy step before scaling out.
- **Request-body validation** is defined (DTOs + class-validator) but only applied selectively; POST/PUT bodies are largely unvalidated.

🤖 Generated with [Claude Code](https://claude.ai/code)